### PR TITLE
fix/windows-empty:  Fix: Filter empty/whitespace-only logs on Windows…

### DIFF
--- a/output/client.go
+++ b/output/client.go
@@ -8,6 +8,7 @@ import (
 	"github.com/fluent/fluent-bit-go/output"
 	"context"
 	"encoding/json"
+	"strings"
 	"github.com/logicmonitor/lm-data-sdk-go/api/logs"
 	"github.com/logicmonitor/lm-data-sdk-go/model"
 	"github.com/logicmonitor/lm-data-sdk-go/utils"
@@ -157,6 +158,10 @@ func (logicmonitorClient *LogicmonitorClient) Send(log []byte, logIngestor *logs
 	} else {
 		logger.Debug(fmt.Sprintf("Message field found: %s", message))
 	}
+
+	// Trim whitespace to handle empty lines on Windows (CRLF) and Linux (LF)
+	// This removes carriage returns (\r), newlines (\n), spaces, tabs, etc.
+	message = strings.TrimSpace(message)
 
   //Send logs only if message is not empty
 	if message != "" {


### PR DESCRIPTION
… and Linux

- Add strings.TrimSpace() to remove \r\n (Windows) and \n (Linux) line endings
- Prevents empty logs from being ingested into LogicMonitor
- Handles carriage returns (\r), newlines (\n), spaces, tabs, and mixed whitespace
- Works transparently across all platforms without configuration changes

Fixes: Empty log lines from Windows CRLF line endings being sent to LogicMonitor
Made-with: Cursor