### PR TITLE
Filter empty/whitespace-only logs on Windows and Linux

### DIFF
--- a/output/client.go
+++ b/output/client.go
@@ -8,6 +8,7 @@ import (
 	"github.com/fluent/fluent-bit-go/output"
 	"context"
 	"encoding/json"
+	"strings"
 	"github.com/logicmonitor/lm-data-sdk-go/api/logs"
 	"github.com/logicmonitor/lm-data-sdk-go/model"
 	"github.com/logicmonitor/lm-data-sdk-go/utils"
@@ -157,6 +158,10 @@ func (logicmonitorClient *LogicmonitorClient) Send(log []byte, logIngestor *logs
 	} else {
 		logger.Debug(fmt.Sprintf("Message field found: %s", message))
 	}
+
+	// Trim whitespace to handle empty lines on Windows (CRLF) and Linux (LF)
+	// This removes carriage returns (\r), newlines (\n), spaces, tabs, etc.
+	message = strings.TrimSpace(message)
 
   //Send logs only if message is not empty
 	if message != "" {


### PR DESCRIPTION
## Why This Issue Occurs( only in windows)
Windows uses CRLF (`\r\n`) line endings while Linux uses LF (`\n`). When Fluent Bit 
reads log files, it can capture these line ending characters as the entire message 
instead of actual log content.
## Changes
- Trim whitespace from log messages using `strings.TrimSpace()`
- Skip sending logs that are empty after trimming
## Testing
Verified with EC2 logs containing messages with only `\r` characters - these are now 
correctly filtered and not sent to LogicMonitor.
## Example
**Before:** Message `"\r"` → Sent as empty log
**After:** Message `"\r"` → Trimmed to `""` → Filtered out (not sent)